### PR TITLE
add support for arm64 builds for use on rpi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,31 @@
 FROM debian:buster-slim as builder
 
 ARG BITCOIN_VERSION="d4a86277ed8a"
-ARG TRIPLET=${TRIPLET:-"x86_64-linux-gnu"}
+ARG TARGETARCH
+ARG TRIPLET
 
 RUN  apt-get update && \
      apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget libc6 procps python3
 WORKDIR /tmp
 
 # install bitcoin binaries
-RUN BITCOIN_URL="https://github.com/benthecarman/bitcoin/releases/download/paircommit/bitcoin-${BITCOIN_VERSION}-${TRIPLET}.tar.gz" && \
+# Set TRIPLET based on TARGETARCH if not provided
+RUN if [ -z "$TRIPLET" ]; then \
+     if [ "$TARGETARCH" = "arm64" ]; then \
+     TRIPLET=aarch64-linux-gnu; \
+     elif [ "$TARGETARCH" = "amd64" ]; then \
+     TRIPLET=x86_64-linux-gnu; \
+     else \
+     TRIPLET=x86_64-linux-gnu; \
+     fi; \
+     fi; \
+     echo "Using TRIPLET=$TRIPLET" && \
+     BITCOIN_URL="https://github.com/benthecarman/bitcoin/releases/download/paircommit/bitcoin-${BITCOIN_VERSION}-${TRIPLET}.tar.gz" && \
      BITCOIN_FILE="bitcoin-${BITCOIN_VERSION}-${TRIPLET}.tar.gz" && \
      wget -qO "${BITCOIN_FILE}" "${BITCOIN_URL}" && \
      mkdir -p bin && \
      tar -xzvf "${BITCOIN_FILE}" -C /tmp/bin --strip-components=2 "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli" "bitcoin-${BITCOIN_VERSION}/bin/bitcoind" "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-wallet" "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-util"
+
 FROM debian:buster-slim as custom-signet-bitcoin
 
 LABEL org.opencontainers.image.authors="NBD"


### PR DESCRIPTION
i wanted to be able to run this image on a raspberry pi cuz i'm cool like that and i make bad decisions. the original dockerfile only would pull in binaries for x86. this uses the [`TARGETARCH` build arg](https://docs.docker.com/reference/dockerfile/#automatic-platform-args-in-the-global-scope) available in multi-platform builds to automatically pull in the x86 or arm build. 

i went ahead and pushed it to docker hub so others can use it that want it. 

https://hub.docker.com/layers/w3irdrobot/mutinynet/latest/images/sha256-26ea93592f4c55a1ab296fc3d7ce2ea971d59dce903830ffb5495da2db81baca

not sure if this is even desired, but here it is anyways.