### PR TITLE
updates Dockerfile to use debian:bullseye-slim instead of debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as builder
+FROM debian:bullseye-slim as builder
 
 ARG BITCOIN_VERSION="d4a86277ed8a"
 ARG TRIPLET=${TRIPLET:-"x86_64-linux-gnu"}
@@ -13,7 +13,7 @@ RUN BITCOIN_URL="https://github.com/benthecarman/bitcoin/releases/download/pairc
      wget -qO "${BITCOIN_FILE}" "${BITCOIN_URL}" && \
      mkdir -p bin && \
      tar -xzvf "${BITCOIN_FILE}" -C /tmp/bin --strip-components=2 "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli" "bitcoin-${BITCOIN_VERSION}/bin/bitcoind" "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-wallet" "bitcoin-${BITCOIN_VERSION}/bin/bitcoin-util"
-FROM debian:buster-slim as custom-signet-bitcoin
+FROM debian:bullseye-slim as custom-signet-bitcoin
 
 LABEL org.opencontainers.image.authors="NBD"
 LABEL org.opencontainers.image.licenses=MIT


### PR DESCRIPTION
Update is to fix issue where `debian-buster-slim` is deprecated, and is currently causing issue during image build process. The following is the error encountered in our CICD pipeline that this change is fixing:

```
#7 [builder 2/4] RUN  apt-get update &&      apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget libc6 procps python3
#7 0.474 Ign:1 http://deb.debian.org/debian buster InRelease
#7 0.477 Ign:2 http://deb.debian.org/debian-security buster/updates InRelease
#7 0.619 Ign:3 http://deb.debian.org/debian buster-updates InRelease
#7 0.765 Err:4 http://deb.debian.org/debian buster Release
#7 0.765   404  Not Found [IP: 151.101.202.132 80]
#7 0.767 Err:5 http://deb.debian.org/debian-security buster/updates Release
#7 0.767   404  Not Found [IP: 151.101.202.132 80]
#7 0.915 Err:6 http://deb.debian.org/debian buster-updates Release
#7 0.915   404  Not Found [IP: 151.101.202.132 80]
#7 0.919 Reading package lists...
#7 0.926 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#7 0.926 E: The repository 'http://deb.debian.org/debian-security buster/updates Release' does not have a Release file.
#7 0.926 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#7 ERROR: process "/bin/sh -c apt-get update &&      apt-get install -qq --no-install-recommends ca-certificates dirmngr gosu wget libc6 procps python3" did not complete successfully: exit code: 100
```

This change was tested in our CICD pipeline and found to be working as expected