### PR TITLE
disk-space-DoS due to low mining difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Mutinynet
 
+
 This repo contains most of the deployment for [Mutinynet](https://mutinynet.com). It originally is a fork
 of [Plebnet](https://github.com/nbd-wtf/bitcoin_signet) but has grown to include a lot more.
 


### PR DESCRIPTION
I wasn't able to create an issue but wanted to let you know about this anyway:

I recently opened an issue regarding public, low-difficulty Signets being vulnerable to a disk-space DoS in https://github.com/bitcoin/bitcoin/issues/33266

With 4838420 work (hash attempts) required to mine a block on Mutinynet at the current difficulty, it's possible to mine 2^32 / 4838420 = 877 valid headers for the same block. Given that Mutinynet has 2880 blocks per day on average, an attacker that's able fill Mutinynet blocks on average with 40 kB of transactions, can fill the disk of an (unpruned) Mutinynet node by 2880 * 877 * 40 kB = 100 GB per day. Given the block time of 30s, an attacker needs to mine and publish the alternative blocks before the next real Mutinynet block is found. This can probably be done with a fast consumer CPU.