### PR TITLE
Add arkade-daemon service and wire it into faucet_backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,6 +327,8 @@ services:
       MAINNET_GRPC_PORT: "10069"
       MAINNET_TLS_CERT_PATH: "/root/faucet_backend/tls.cert"
       MAINNET_ADMIN_MACAROON_PATH: "/root/faucet_backend/reorg.macaroon"
+      ARKADE_DAEMON_URL: "http://arkade-daemon:8080"
+      ARKADE_INTERNAL_TOKEN: $ARKADE_INTERNAL_TOKEN
     user: "0:1000"
     logging: *default-logging
     restart: always
@@ -337,6 +339,27 @@ services:
       - ~/volumes/faucet_backend:/root/faucet_backend
     ports:
       - "3001:3001"
+  arkade-daemon:
+    container_name: "arkade-daemon"
+    image: ghcr.io/kukks/arkade-faucet-daemon:latest
+    user: "0:1000"
+    logging: *default-logging
+    restart: always
+    stop_grace_period: 1m
+    environment:
+      ARKADE_MNEMONIC: $ARKADE_MNEMONIC
+      ARK_SERVER_URL: "https://mutinynet.arkade.sh"
+      IS_MAINNET: "false"
+      DB_PATH: "/data/arkade-wallet.sqlite"
+      MAX_SEND: "100000"
+      MIN_BALANCE: "100000"
+      REPLENISH_AMOUNT: "1000000"
+      # Replenish from the local faucet backend on the internal network.
+      FAUCET_API: "http://faucet_backend:3001"
+      FAUCET_API_TOKEN: $ARKADE_FAUCET_TOKEN
+      INTERNAL_TOKEN: $ARKADE_INTERNAL_TOKEN
+    volumes:
+      - ~/volumes/arkade-daemon:/data
   fortune_402:
     container_name: "fortune_402"
     image: ghcr.io/benthecarman/fortune-402:master


### PR DESCRIPTION
Adds an `arkade-daemon` service to the compose file and hooks it up to `faucet_backend` so the faucet's new `POST /api/arkade` (MutinyWallet/mutinynet-faucet-rs#13) has somewhere to forward to.

The daemon runs `ghcr.io/kukks/arkade-faucet-daemon` (source at [Kukks/arkade-faucet-daemon](https://github.com/Kukks/arkade-faucet-daemon)) — a small Node service that holds an Arkade wallet, exposes `POST /send` on the internal network, and auto-tops-up by calling the faucet backend's own `/api/onchain`. No published port; only `faucet_backend` reaches it. Wallet + SQLite state persist under `~/volumes/arkade-daemon/`.

Two new env vars the operator needs to supply:

- `ARKADE_MNEMONIC` — the daemon's wallet seed. Generate one with `docker run --rm ghcr.io/kukks/arkade-faucet-daemon:latest node gen-mnemonic.js`.
- `ARKADE_FAUCET_TOKEN` — the `Authorization` header value the daemon uses to hit the faucet's `/api/onchain` for replenishment. Should be an L402 credential or a long-lived JWT accepted by the faucet. Leave empty and auto-replenish is disabled — the daemon still runs, you just top it up manually.

Optional `ARKADE_INTERNAL_TOKEN` becomes a shared secret checked on the daemon's `/send`. Off by default since the daemon is only reachable inside the compose network.

Sizing (`MIN_BALANCE=100000`, `REPLENISH_AMOUNT=1000000`, `MAX_SEND=100000`) matches the daemon defaults and keeps replenish requests infrequent enough to sit inside the faucet's rate limits — happy to lower `REPLENISH_AMOUNT` if you'd prefer smaller more-frequent top-ups. Pinning `:latest` is convenient for now; a specific `:sha-…` tag once this stabilises is fine too.

Pairs with the frontend change in MutinyWallet/mutinynet-faucet#18 and the backend route in MutinyWallet/mutinynet-faucet-rs#13. Compose file validates (`docker compose config`).